### PR TITLE
WTEL-9111: Fix comments leak

### DIFF
--- a/internal/app/case.go
+++ b/internal/app/case.go
@@ -123,6 +123,11 @@ func (c *CaseService) SearchCases(ctx context.Context, req *cases.SearchCasesReq
 		return nil, err
 	}
 
+	if authOpts := searchOpts.GetAuthOpts(); authOpts != nil &&
+		!authOpts.CheckObacAccess(model.ScopeCaseComments, auth.Read) {
+		searchOpts.Fields = util.RemoveSliceElement(searchOpts.Fields, "comments")
+	}
+
 	ftsFilters := util.GetFilter(req.GetFilters(), "fts")
 	if len(ftsFilters) > 0 && len(req.GetIds()) == 0 {
 		return &cases.CaseList{
@@ -162,6 +167,12 @@ func (c *CaseService) LocateCase(ctx context.Context, req *cases.LocateCaseReque
 	if err != nil {
 		return nil, err
 	}
+
+	if authOpts := searchOpts.GetAuthOpts(); authOpts != nil &&
+		!authOpts.CheckObacAccess(model.ScopeCaseComments, auth.Read) {
+		searchOpts.Fields = util.RemoveSliceElement(searchOpts.Fields, "comments")
+	}
+
 	list, err := c.app.Store.Case().List(searchOpts)
 	if err != nil {
 		return nil, err

--- a/internal/store/postgres/case.go
+++ b/internal/store/postgres/case.go
@@ -3192,6 +3192,9 @@ func (c *CaseStore) buildCaseSelectColumnsAndPlan(
 				return scanner.ScanRowLookup(&caseItem.SlaCondition)
 			})
 		case "comments":
+			if auther != nil && !auther.CheckObacAccess(model.ScopeCaseComments, auth.Read) {
+				continue
+			}
 			commentFields := []string{"id", "ver", "text", "created_by", "author", "created_at", "can_edit"}
 			subquery, scanPlan, dbErr := buildCommentsSelectAsSubquery(auther, commentFields, base.TableAlias)
 			if dbErr != nil {

--- a/internal/store/postgres/case.go
+++ b/internal/store/postgres/case.go
@@ -3192,9 +3192,6 @@ func (c *CaseStore) buildCaseSelectColumnsAndPlan(
 				return scanner.ScanRowLookup(&caseItem.SlaCondition)
 			})
 		case "comments":
-			if auther != nil && !auther.CheckObacAccess(model.ScopeCaseComments, auth.Read) {
-				continue
-			}
 			commentFields := []string{"id", "ver", "text", "created_by", "author", "created_at", "can_edit"}
 			subquery, scanPlan, dbErr := buildCommentsSelectAsSubquery(auther, commentFields, base.TableAlias)
 			if dbErr != nil {


### PR DESCRIPTION
## Проблема
В реєстрі звернень (`/api/cases?fields=comments`) коментарі віддавались користувачу, у якого роль не мала OBAC-права `Read` на обʼєкт `case_comments`. На картці звернення коментарі коректно ховались, тобто був неузгоджений рівень доступу.

Корінь: при формуванні підзапиту на коментарі у store-шарі застосовувалась лише RBAC-перевірка через `addCaseCommentRbacCondition`. Коли на скоупі `case_comments` увімкнено тільки OBAC, а RBAC вимкнено, `IsRbacCheckRequired` повертав `false`, фільтр не додавався і підзапит віддавав усі коментарі без обмежень. gRPC-перехоплювач на вході в `Cases.SearchCases` валідує лише скоуп `cases`, тому дочірній `case_comments` через `fields=comments` проходив непомітно.

## Вирішення
Додано явну OBAC-перевірку в гілці `case "comments":` перед побудовою підзапиту. Якщо у сесії немає OBAC `Read` на `case_comments` - поле просто пропускається через `continue`, БД не запитується, поле не зʼявляється у відповіді.