### PR TITLE
WTEL-9700: FTS export - search cases scope only

### DIFF
--- a/internal/app/case_fts_export.go
+++ b/internal/app/case_fts_export.go
@@ -18,7 +18,7 @@ const (
 )
 
 // ftsExportObjectNames lists the FTS object scopes searched during export.
-var ftsExportObjectNames = []string{"cases", "case_comments"}
+var ftsExportObjectNames = []string{"cases"}
 
 func (c *CaseService) resolveFtsIdsForExport(ctx context.Context, req *cases.ExportCasesRequest) (bool, error) {
 	ftsFilters, rest := util.PartitionFilter(req.GetFilters(), "fts")


### PR DESCRIPTION
## Проблема
Повнотекстовий пошук (FTS) повертав різну кількість звернень у списку UI та в експортованому файлі. Приклади на тесті:
  - пошук sd: у UI 7 звернень, в експорті 14;
  - пошук new: у UI 4 звернення, в експорті близько 38, серед яких більшість взагалі не відповідали запиту (наприклад Футбол, Форд, FTS test).
Причина: під час експорту FTS-запит виконувався по двох скоупах - cases і case_comments. Коментарі індексуються в FTS під власним id коментаря, а відповідь сервісу (SearchData) повертає лише цей id, без батьківського case_id. Експорт використовував цей id коментаря як id звернення у фільтрі c.id = ANY(...). Оскільки коментарі мають окрему послідовність case_comment_id (теж з малих чисел), ці значення збігалися з id сторонніх звернень, що давало невалідні та задубльовані рядки.

## Вирішення
Обмежено скоуп FTS-пошуку для експорту лише до cases, тобто пошук тільки по полях самого звернення - так само, як це робить пошук у списку (UI). Завдяки цьому набір звернень в експорті збігається з тим, що бачить користувач у списку (sd -> 14, new -> 4), без невалідних колізій.