### PR TITLE
chore: align EnvironmentFile path with standardized env file

### DIFF
--- a/deploy/systemd/webitel-cases.service
+++ b/deploy/systemd/webitel-cases.service
@@ -9,7 +9,7 @@ TimeoutStartSec=0
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=WebitelCases
-EnvironmentFile=/etc/default/webitel-cases.env
+EnvironmentFile=/etc/default/webitel-cases
 ExecStart=/usr/local/bin/webitel-cases
 
 [Install]


### PR DESCRIPTION
Drops the `.env` suffix: `EnvironmentFile=/etc/default/webitel-cases` to match the standardized package dst. Same fix as webitel-fts#70 / webrtc_recorder#66; missed in the cases env rename PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)