### PR TITLE
refactor(version): inject CurrentVersion via ldflags

### DIFF
--- a/internal/model/version.go
+++ b/internal/model/version.go
@@ -1,14 +1,3 @@
 package model
 
-var versions = []string{
-	"26.04",
-	"26.02",
-	"25.12",
-	"25.10",
-	"25.08",
-	"25.05",
-	"25.04",
-	"25.02",
-}
-
-var CurrentVersion = versions[0]
+var CurrentVersion = "dev"


### PR DESCRIPTION
## What
Drop the hardcoded `versions[]` slice; `CurrentVersion` now defaults to `"dev"` and is injected at build time via `-ldflags` (`-X <module>/<pkg>.CurrentVersion=<version>`).

## Why
Removes the need to manually bump the version slice each release — the version comes from the build pipeline (branch/tag).

## Notes
- Workflow ldflags injection is handled separately (reusable-configs); no workflow files touched here.
- `"dev"` remains the fallback for local builds and tests.